### PR TITLE
Add project install instructions to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ people have made! The Discord is also a great place to find strong opponents to 
 </p>
 
 
+# Project installation
+
+To get the project working, you need a working version of the java JDK (I use 17 personally) and [Apache Maven](https://maven.apache.org/download.cgi) which you can install easily on windows using chocolatey: `choco install maven`
+
+Once those dependencies are installed, run `mvn install` at the root of the project. This will ensure all tests pass and that the CLI is built properly inside `target/CLI.jar`
+
 # 💡 Our current Insights
 If you'd like to learn more about questions such as:
 


### PR DESCRIPTION
I should have waited a month for the Hacktoberfest... but I couldn't. So here it is!

I could not get the project to install following the instructions in the readme, so I "reverse-engineered" them as I don't really code in Java. 

Have fun!

Note: I could not get `mvn package -Pwasm` to work this way:

![image](https://user-images.githubusercontent.com/3145639/188770627-a8d27fff-e8af-4226-9ed1-4d6ae41e11db.png)
